### PR TITLE
Add "setTime" function

### DIFF
--- a/InfluxData.h
+++ b/InfluxData.h
@@ -18,9 +18,9 @@ class InfluxData {
     _values = (_values == "") ? (" ") : (_values += ",");
     _values += key + "=" + String(value);
   }
-  void setTime(long int value)
+  void setTimestamp(long int seconds)
   {
-    _time = " " + String(value) + "000000000";
+    _timestamp = " " + String(seconds) + "000000000";
   }
 
   String toString() const { return _measurement + _tags + _values + _time; }
@@ -29,5 +29,5 @@ class InfluxData {
   String _measurement;
   String _tags;
   String _values;
-  String _time;
+  String _timestamp;
 };

--- a/InfluxData.h
+++ b/InfluxData.h
@@ -18,11 +18,16 @@ class InfluxData {
     _values = (_values == "") ? (" ") : (_values += ",");
     _values += key + "=" + String(value);
   }
+  void setTime(long int value)
+  {
+    _time = " " + String(value) + "000000000";
+  }
 
-  String toString() const { return _measurement + _tags + _values; }
+  String toString() const { return _measurement + _tags + _values + _time; }
 
  private:
   String _measurement;
   String _tags;
   String _values;
+  String _time;
 };


### PR DESCRIPTION
Usecase:
- wake ESP every 5 minutes from deepSleep to make a measurement and store it locally.
- send all the data every 30 minutes to InfluxDB with correct timestamps of previous measurements.

https://docs.influxdata.com/influxdb/v1.7/tools/api/#example-1-write-a-point-to-the-database-mydb-with-a-nanosecond-timestamp

Works for me with a time_t as argument.
```
configTime(0, 0, "pool.ntp.org");
time_t now = time(nullptr);
```

(I'm calculating previous timestamps with "now" & "sleepTimeDuration" to avoid wifi in all the runs that get stored locally and only establish a connection in a run that also writes to the database; the small change in the code works for me ;-)