### PR TITLE
ESP32 support

### DIFF
--- a/InfluxDb.h
+++ b/InfluxDb.h
@@ -6,9 +6,14 @@
 
     @author Tobias Schürg
 */
+#if defined(ESP8266)
 #include <ESP8266HTTPClient.h>
+#elif defined(ESP32)
+#include <WiFi.h>
+#include <HTTPClient.h>
 #include <list>
 #include "Arduino.h"
+#endif
 
 #include "InfluxData.h"
 


### PR DESCRIPTION
This PS makes it possible to compile and use this library with the ESP32.

Solves part of the https://github.com/tobiasschuerg/ESP8266_Influx_DB/issues/5 but does not add the TLS support.