### PR TITLE
ESP32 support

### DIFF
--- a/InfluxDb.h
+++ b/InfluxDb.h
@@ -6,7 +6,13 @@
 
     @author Tobias Schürg
 */
+#if defined(ESP8266)
 #include <ESP8266HTTPClient.h>
+#elif defined(ESP32)
+#include <WiFi.h>
+#include <HTTPClient.h>
+#endif
+
 #include <list>
 #include "Arduino.h"
 


### PR DESCRIPTION
This PS makes it possible to compile and use this library with the ESP32.

Solves part of the #5 but does not add the TLS support.