### PR TITLE
Change to avoid attempting to read an Empty HTTP response on ESP32

### DIFF
--- a/InfluxDb.cpp
+++ b/InfluxDb.cpp
@@ -47,7 +47,7 @@ void Influxdb::setBucket(String bucket) {
 }
 
 /**
- * Set the influxDB port. 
+ * Set the influxDB port.
  * @param port v1.x uses 8086, v2 uses 9999
  */
 void Influxdb::setPort(uint16_t port){
@@ -163,11 +163,21 @@ boolean Influxdb::write(String data) {
   Serial.print(" <-- Response: ");
   Serial.print(httpResponseCode);
 
+#if defined(ESP32)
+  if (http.getSize() > 0) {
+    String response = http.getString();
+    Serial.println(" \"" + response + "\"");
+  }
+  else {
+    Serial.println();
+  }
+#else
   String response = http.getString();
   Serial.println(" \"" + response + "\"");
+#endif
 
   boolean success;
-  if (httpResponseCode == 204) {
+  if (httpResponseCode == HTTP_CODE_NO_CONTENT) {
     success = true;
   } else {
     Serial.println("#####\nPOST FAILED\n#####");

--- a/InfluxDb.cpp
+++ b/InfluxDb.cpp
@@ -164,6 +164,8 @@ boolean Influxdb::write(String data) {
   Serial.print(httpResponseCode);
 
 #if defined(ESP32)
+  // The ESP32 HTTP Lib seems to hang if you call getString if the server has not
+  // written anything in response.
   if (http.getSize() > 0) {
     String response = http.getString();
     Serial.println(" \"" + response + "\"");


### PR DESCRIPTION
I'd been experiencing hangs when using this library on an ESP32 + InfluxDB 1.7.9. I would write measurements and find they would never return.

I'm not attached to the approach, feel free to let me know if there's anything you'd like to change before merging.