### PR TITLE
Add the ability to specify decimal places for float values

### DIFF
--- a/InfluxData.h
+++ b/InfluxData.h
@@ -14,9 +14,9 @@ class InfluxData {
   InfluxData(String measurement) : _measurement(measurement) {}
 
   void addTag(String key, String value) { _tags += "," + key + "=" + value; }
-  void addValue(String key, float value) {
+  void addValue(String key, float value, int decimals = 2) {
     _values = (_values == "") ? (" ") : (_values += ",");
-    _values += key + "=" + String(value);
+    _values += key + "=" + String(value, decimals);
   }
   void addValueString(String key, String value) {
     _values = (_values == "") ? (" ") : (_values += ",");


### PR DESCRIPTION
I found the default number of decimals in String() is two, which was insufficient for my code (it meant an accuracy of 10W instead of 1W for my electricity metering)